### PR TITLE
Add clang-format file and clang-format target

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,107 @@
+---
+Language:        Cpp
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:   100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,3 +110,6 @@ install_basic_package_files(${PROJECT_NAME}
                             NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 # Add the uninstall target
 include(AddUninstallTarget)
+
+# Include clang-format target
+include(AddClangFormatTarget)

--- a/cmake/AddClangFormatTarget.cmake
+++ b/cmake/AddClangFormatTarget.cmake
@@ -1,0 +1,31 @@
+# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia
+#
+# Licensed under either the GNU Lesser General Public License v3.0 :
+# https://www.gnu.org/licenses/lgpl-3.0.html
+# or the GNU Lesser General Public License v2.1 :
+# https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+# at your option.
+
+# Targets to run and check source code with clang-format
+# Inspired from https://gitlab.cern.ch/unige-fei4tel/proteus/commit/8d906a45801c03832531e243f41f5f5a83177de0
+
+# Adding clang-format check and formatter if found
+find_program(CLANG_FORMAT "clang-format")
+if(CLANG_FORMAT)
+  file(GLOB_RECURSE
+       CHECK_CXX_SOURCE_FILES
+       ${PROJECT_SOURCE_DIR}/*.h
+       ${PROJECT_SOURCE_DIR}/*.cpp
+       ${PROJECT_SOURCE_DIR}/*.hh
+       ${PROJECT_SOURCE_DIR}/*.cc)
+  add_custom_target(
+      clang-format
+      COMMAND
+      ${CLANG_FORMAT}
+      -i
+      -style=file
+      ${CHECK_CXX_SOURCE_FILES}
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src
+      COMMENT "Auto formatting of all source files using clang-format"
+  )
+endif()

--- a/src/sdf-modelica-lib/include/sdf_modelica/nlohmann_json_to_kainjow_mustache.h
+++ b/src/sdf-modelica-lib/include/sdf_modelica/nlohmann_json_to_kainjow_mustache.h
@@ -14,11 +14,10 @@
 
 #include <string>
 
-#include <nlohmann/json.hpp>
 #include <mustache.hpp>
+#include <nlohmann/json.hpp>
 
-namespace sdf_modelica
-{
+namespace sdf_modelica {
 
 /**
  * @brief Convert a  nlohmann::json to a kainjow::mustache::data
@@ -38,6 +37,6 @@ bool nlohmann_json_to_kainjow_mustache(const nlohmann::json& inputData,
  */
 kainjow::mustache::data nlohmann_json_to_kainjow_mustache(const nlohmann::json& inputData);
 
-}
+} // namespace sdf_modelica
 
 #endif

--- a/src/sdf-modelica-lib/include/sdf_modelica/sdf_modelica.h
+++ b/src/sdf-modelica-lib/include/sdf_modelica/sdf_modelica.h
@@ -9,7 +9,6 @@
  * at your option.
  */
 
-
 #ifndef SDF_MODELICA_H
 #define SDF_MODELICA_H
 
@@ -17,8 +16,7 @@
 
 #include <sdf/sdf.hh>
 
-namespace sdf_modelica
-{
+namespace sdf_modelica {
 
 /**
  * \brief Options for the SDF Modelica converter
@@ -27,12 +25,12 @@ struct SDFModelicaOptions
 {
 
     /**
-      * Original filename of the converted SDF.
-      *
-      * This filename is inserted in the generate modelica model.
-      *
-      * Default: empty string.
-      */
+     * Original filename of the converted SDF.
+     *
+     * This filename is inserted in the generate modelica model.
+     *
+     * Default: empty string.
+     */
     std::string originalFilename{""};
 
     /**
@@ -40,15 +38,14 @@ struct SDFModelicaOptions
      *
      * Default: the base frame of the model.
      */
-    //std::vector<std::string> baseFrameConnectors;
+    // std::vector<std::string> baseFrameConnectors;
 
     /**
      * Frame connectors rendered on the top of the component.
      *
      * Default: empty
      */
-    //std::vector<std::string> topFrameConnectors;
-
+    // std::vector<std::string> topFrameConnectors;
 
     /**
      * Constructor, containing default values.
@@ -68,7 +65,7 @@ struct SDFModelicaOptions
  */
 bool modelicaFromSDFFile(const std::string& sdf_filename,
                          std::string& modelica_model,
-                         const SDFModelicaOptions options=SDFModelicaOptions());
+                         const SDFModelicaOptions options = SDFModelicaOptions());
 
 /**
  * \brief Create a Modelica model object from a SDF string.
@@ -80,7 +77,7 @@ bool modelicaFromSDFFile(const std::string& sdf_filename,
  */
 bool modelicaFromSDFString(const std::string& sdf_string,
                            std::string& modelica_model,
-                           const SDFModelicaOptions options=SDFModelicaOptions());
+                           const SDFModelicaOptions options = SDFModelicaOptions());
 
 /**
  * \brief Create a Modelica model object from a SDF object.
@@ -92,9 +89,8 @@ bool modelicaFromSDFString(const std::string& sdf_string,
  */
 bool modelicaFromSDF(sdf::SDFPtr sdf,
                      std::string& modelica_model,
-                     const SDFModelicaOptions options=SDFModelicaOptions());
+                     const SDFModelicaOptions options = SDFModelicaOptions());
 
-
-}
+} // namespace sdf_modelica
 
 #endif

--- a/src/sdf-modelica-lib/include/sdf_modelica/sdf_modelica_diagram_layout.h
+++ b/src/sdf-modelica-lib/include/sdf_modelica/sdf_modelica_diagram_layout.h
@@ -17,8 +17,7 @@
 #include <ignition/math/graph/Graph.hh>
 #include <nlohmann/json.hpp>
 
-namespace sdf_modelica
-{
+namespace sdf_modelica {
 
 enum ConnectionSide
 {
@@ -36,12 +35,19 @@ struct ModelicaGraphComponentInfo
     bool fixedLocation;
     int fixedLocationModelicaUnitsX;
     int fixedLocationModelicaUnitsY;
-    ModelicaGraphComponentInfo(): name(""), fixedLocation(false),
-                                  fixedLocationModelicaUnitsX(0), fixedLocationModelicaUnitsY(0) {};
-    ModelicaGraphComponentInfo(std::string arg_name, bool a_fixedLocation=false,
-                                int a_fixedLocationModelicaUnitsX=0, int a_fixedLocationModelicaUnitsY=0):
-      name(arg_name), fixedLocation(a_fixedLocation),
-      fixedLocationModelicaUnitsX(a_fixedLocationModelicaUnitsX), fixedLocationModelicaUnitsY(a_fixedLocationModelicaUnitsY) {};
+    ModelicaGraphComponentInfo()
+        : name("")
+        , fixedLocation(false)
+        , fixedLocationModelicaUnitsX(0)
+        , fixedLocationModelicaUnitsY(0){};
+    ModelicaGraphComponentInfo(std::string arg_name,
+                               bool a_fixedLocation = false,
+                               int a_fixedLocationModelicaUnitsX = 0,
+                               int a_fixedLocationModelicaUnitsY = 0)
+        : name(arg_name)
+        , fixedLocation(a_fixedLocation)
+        , fixedLocationModelicaUnitsX(a_fixedLocationModelicaUnitsX)
+        , fixedLocationModelicaUnitsY(a_fixedLocationModelicaUnitsY){};
 };
 
 /**
@@ -51,13 +57,16 @@ struct ModelicaGraphConnectionInfo
 {
     ConnectionSide firstSide;
     ConnectionSide secondSide;
-    ModelicaGraphConnectionInfo(): firstSide(EAST), secondSide(WEST) {};
-    ModelicaGraphConnectionInfo(ConnectionSide first, ConnectionSide second):
-      firstSide(first), secondSide(second) {};
+    ModelicaGraphConnectionInfo()
+        : firstSide(EAST)
+        , secondSide(WEST){};
+    ModelicaGraphConnectionInfo(ConnectionSide first, ConnectionSide second)
+        : firstSide(first)
+        , secondSide(second){};
 };
 
-using DiagramGraph = ignition::math::graph::DirectedGraph<ModelicaGraphComponentInfo, ModelicaGraphConnectionInfo>;
-
+using DiagramGraph
+    = ignition::math::graph::DirectedGraph<ModelicaGraphComponentInfo, ModelicaGraphConnectionInfo>;
 
 /**
  * Add diagram layout annotations using a simple hand-written model.
@@ -68,9 +77,7 @@ using DiagramGraph = ignition::math::graph::DirectedGraph<ModelicaGraphComponent
  * @param[in,out] modelData data used the for the mustache template generation
  * @return        true if all went well, false otherwise
  */
-bool add_diagram_layout_handtuned(const DiagramGraph& modelGraph,
-                                  nlohmann::json& modelData);
-
+bool add_diagram_layout_handtuned(const DiagramGraph& modelGraph, nlohmann::json& modelData);
 
 /**
  * Add empty diagram layout annotations.
@@ -82,8 +89,7 @@ bool add_diagram_layout_handtuned(const DiagramGraph& modelGraph,
  * @param[in,out] modelData data used the for the mustache template generation
  * @return        true if all went well, false otherwise
  */
-bool add_diagram_layout_dummy(const DiagramGraph& modelGraph,
-                              nlohmann::json& modelData);
+bool add_diagram_layout_dummy(const DiagramGraph& modelGraph, nlohmann::json& modelData);
 
 /**
  * Add annotation for the icon rappresentation of the model.
@@ -93,12 +99,14 @@ bool add_diagram_layout_dummy(const DiagramGraph& modelGraph,
  *
  * @param[in,out]      graph    graph of Modelica-component connections
  * @param[in,out] modelData data used the for the mustache template generation
- * @param[in,out] modelicaComponent2ignGraphId map between modelica component names and ign graph VertexId
+ * @param[in,out] modelicaComponent2ignGraphId map between modelica component names and ign graph
+ * VertexId
  * @return        true if all went well, false otherwise
  */
-bool add_icon_layout(DiagramGraph& modelGraph,
-                     nlohmann::json& modelData,
-                     std::map<std::string, ignition::math::graph::VertexId>& modelicaComponent2ignGraphId);
-}
+bool add_icon_layout(
+    DiagramGraph& modelGraph,
+    nlohmann::json& modelData,
+    std::map<std::string, ignition::math::graph::VertexId>& modelicaComponent2ignGraphId);
+} // namespace sdf_modelica
 
 #endif

--- a/src/sdf-modelica-lib/include/sdf_modelica/sdf_modelica_diagram_layout_graphviz.h
+++ b/src/sdf-modelica-lib/include/sdf_modelica/sdf_modelica_diagram_layout_graphviz.h
@@ -19,10 +19,7 @@
 
 #include <sdf_modelica/sdf_modelica_diagram_layout.h>
 
-
-namespace sdf_modelica
-{
-
+namespace sdf_modelica {
 
 /**
  * Add diagram layout annotations using graphviz.
@@ -34,6 +31,6 @@ namespace sdf_modelica
 bool add_diagram_layout_graphviz(const sdf_modelica::DiagramGraph& modelGraph,
                                  nlohmann::json& modelData);
 
-}
+} // namespace sdf_modelica
 
 #endif

--- a/src/sdf-modelica-lib/src/nlohmann_json_to_kainjow_mustache.cpp
+++ b/src/sdf-modelica-lib/src/nlohmann_json_to_kainjow_mustache.cpp
@@ -11,10 +11,10 @@
 
 #include <sdf_modelica/nlohmann_json_to_kainjow_mustache.h>
 
-namespace sdf_modelica
-{
+namespace sdf_modelica {
 
-bool nlohmann_json_to_kainjow_mustache(const nlohmann::json& inputData, kainjow::mustache::data& outputData)
+bool nlohmann_json_to_kainjow_mustache(const nlohmann::json& inputData,
+                                       kainjow::mustache::data& outputData)
 {
     outputData = nlohmann_json_to_kainjow_mustache(inputData);
     return true;
@@ -24,8 +24,7 @@ kainjow::mustache::data nj_to_jm_object_helper(const nlohmann::json& inputData)
 {
     assert(inputData.type() == nlohmann::json::value_t::object);
     kainjow::mustache::data km_data;
-    for (nlohmann::json::const_iterator it = inputData.begin(); it != inputData.end(); ++it)
-    {
+    for (nlohmann::json::const_iterator it = inputData.begin(); it != inputData.end(); ++it) {
         km_data[it.key()] = nlohmann_json_to_kainjow_mustache(it.value());
     }
     return km_data;
@@ -35,8 +34,7 @@ kainjow::mustache::data nj_to_jm_array_helper(const nlohmann::json& inputData)
 {
     assert(inputData.type() == nlohmann::json::value_t::array);
     kainjow::mustache::data km_list{kainjow::mustache::data::type::list};
-    for (nlohmann::json::const_iterator it = inputData.begin(); it != inputData.end(); ++it)
-    {
+    for (nlohmann::json::const_iterator it = inputData.begin(); it != inputData.end(); ++it) {
         km_list.push_back(nlohmann_json_to_kainjow_mustache(*it));
     }
     return km_list;
@@ -46,42 +44,38 @@ kainjow::mustache::data nlohmann_json_to_kainjow_mustache(const nlohmann::json& 
 {
     nlohmann::json::value_t type = inputData.type();
 
-    switch(type)
-    {
-        case nlohmann::json::value_t::null:
-            return kainjow::mustache::data();
-            break;
-        case nlohmann::json::value_t::object:
-            return nj_to_jm_object_helper(inputData);
-            break;
-        case nlohmann::json::value_t::array:
-            return nj_to_jm_array_helper(inputData);
-            break;
-        case nlohmann::json::value_t::string:
-            return kainjow::mustache::data(inputData.get<std::string>());
-            break;
-        case nlohmann::json::value_t::boolean:
-            return kainjow::mustache::data(inputData.get<bool>());
-            break;
-        case nlohmann::json::value_t::number_integer:
-            return kainjow::mustache::data(std::to_string(inputData.get<int>()));
-            break;
-        case nlohmann::json::value_t::number_unsigned:
-            return kainjow::mustache::data(std::to_string(inputData.get<unsigned int>()));
-            break;
-        case nlohmann::json::value_t::number_float:
-            return kainjow::mustache::data(std::to_string(inputData.get<double>()));
-            break;
-        case nlohmann::json::value_t::discarded:
-            return kainjow::mustache::data();
-            break;
-        default:
-            return kainjow::mustache::data();
-            break;
+    switch (type) {
+    case nlohmann::json::value_t::null:
+        return kainjow::mustache::data();
+        break;
+    case nlohmann::json::value_t::object:
+        return nj_to_jm_object_helper(inputData);
+        break;
+    case nlohmann::json::value_t::array:
+        return nj_to_jm_array_helper(inputData);
+        break;
+    case nlohmann::json::value_t::string:
+        return kainjow::mustache::data(inputData.get<std::string>());
+        break;
+    case nlohmann::json::value_t::boolean:
+        return kainjow::mustache::data(inputData.get<bool>());
+        break;
+    case nlohmann::json::value_t::number_integer:
+        return kainjow::mustache::data(std::to_string(inputData.get<int>()));
+        break;
+    case nlohmann::json::value_t::number_unsigned:
+        return kainjow::mustache::data(std::to_string(inputData.get<unsigned int>()));
+        break;
+    case nlohmann::json::value_t::number_float:
+        return kainjow::mustache::data(std::to_string(inputData.get<double>()));
+        break;
+    case nlohmann::json::value_t::discarded:
+        return kainjow::mustache::data();
+        break;
+    default:
+        return kainjow::mustache::data();
+        break;
     }
 }
 
-
-
-
-}
+} // namespace sdf_modelica

--- a/src/sdf-modelica-lib/src/sdf_modelica.cpp
+++ b/src/sdf-modelica-lib/src/sdf_modelica.cpp
@@ -9,10 +9,10 @@
  * at your option.
  */
 
+#include <sdf_modelica/nlohmann_json_to_kainjow_mustache.h>
 #include <sdf_modelica/sdf_modelica.h>
 #include <sdf_modelica/sdf_modelica_diagram_layout.h>
 #include <sdf_modelica/sdf_modelica_diagram_layout_graphviz.h>
-#include <sdf_modelica/nlohmann_json_to_kainjow_mustache.h>
 
 #include <ignition/math/Matrix3.hh>
 #include <ignition/math/Pose3.hh>
@@ -23,327 +23,320 @@
 
 #include <mustache.hpp>
 
-
 #include "template_path.hpp"
 #include <cassert>
 #include <map>
-#include <sstream>
 #include <regex>
+#include <sstream>
 
-namespace sdf_modelica
-{
-
+namespace sdf_modelica {
 
 bool modelicaFromSDFFile(const std::string& sdf_filename,
                          std::string& modelica_model,
                          const SDFModelicaOptions options)
 {
-  sdf::SDFPtr sdfElement(new sdf::SDF());
-  sdf::init(sdfElement);
-  if (!sdf::readFile(sdf_filename, sdfElement))
-  {
-    std::cerr << "sdf_modelica: " << sdf_filename << " is not a valid SDF file." << std::endl;
-    return false;
-  }
+    sdf::SDFPtr sdfElement(new sdf::SDF());
+    sdf::init(sdfElement);
+    if (!sdf::readFile(sdf_filename, sdfElement)) {
+        std::cerr << "sdf_modelica: " << sdf_filename << " is not a valid SDF file." << std::endl;
+        return false;
+    }
 
-  SDFModelicaOptions modifiableOptions(options);
-  modifiableOptions.originalFilename = sdf_filename;
+    SDFModelicaOptions modifiableOptions(options);
+    modifiableOptions.originalFilename = sdf_filename;
 
-  return modelicaFromSDF(sdfElement, modelica_model, modifiableOptions);
+    return modelicaFromSDF(sdfElement, modelica_model, modifiableOptions);
 }
 
 bool modelicaFromSDFString(const std::string& sdf_string,
                            std::string& modelica_model,
                            const SDFModelicaOptions options)
 {
-  sdf::SDFPtr sdfElement(new sdf::SDF());
-  sdf::init(sdfElement);
-  if (!sdf::readString(sdf_string, sdfElement))
-  {
-    std::cerr << "sdf_modelica: " << sdf_string << " is not a valid SDF string." << std::endl;
-    return false;
-  }
+    sdf::SDFPtr sdfElement(new sdf::SDF());
+    sdf::init(sdfElement);
+    if (!sdf::readString(sdf_string, sdfElement)) {
+        std::cerr << "sdf_modelica: " << sdf_string << " is not a valid SDF string." << std::endl;
+        return false;
+    }
 
-  return modelicaFromSDF(sdfElement, modelica_model, options);
+    return modelicaFromSDF(sdfElement, modelica_model, options);
 }
 
 bool isIdentity(const ignition::math::Quaterniond& q, const double tol = 1e-7)
 {
-    return (std::abs((q.W()-1)) < tol) &&
-               (std::abs(q.X()) < tol) &&
-               (std::abs(q.Y()) < tol) &&
-               (std::abs(q.Z()) < tol);
+    return (std::abs((q.W() - 1)) < tol) && (std::abs(q.X()) < tol) && (std::abs(q.Y()) < tol)
+           && (std::abs(q.Z()) < tol);
 }
 
 // Unfortunatly, the overloading of operator* is extremly counterintuitive,
 // especially if you are used to work with 4x4 homogeneous matrices
-// See https://bitbucket.org/osrf/gazebo/issues/216/pose-addition-and-subtraction-needs-work#comment-18702360
-ignition::math::Pose3d SE3Multiplication(const ignition::math::Pose3d& firstTerm, const ignition::math::Pose3d& secondTerm)
+// See
+// https://bitbucket.org/osrf/gazebo/issues/216/pose-addition-and-subtraction-needs-work#comment-18702360
+ignition::math::Pose3d SE3Multiplication(const ignition::math::Pose3d& firstTerm,
+                                         const ignition::math::Pose3d& secondTerm)
 {
-  return (firstTerm*secondTerm).Inverse();
+    return (firstTerm * secondTerm).Inverse();
 }
 
 // Convert a ign vector to a string in modelica format
 std::string toModelicaVector(const ignition::math::Vector3d& vec)
 {
-  // TODO(traversaro): find a way to express a floating point number without
-  // losing precision, but also using the minimal number of chars
-  std::stringstream ss;
-  ss << "{" << vec.X() << "," << vec.Y() << "," << vec.Z() << "}";
-  return ss.str();
+    // TODO(traversaro): find a way to express a floating point number without
+    // losing precision, but also using the minimal number of chars
+    std::stringstream ss;
+    ss << "{" << vec.X() << "," << vec.Y() << "," << vec.Z() << "}";
+    return ss.str();
 }
 
-bool modelicaFromSDF(sdf::SDFPtr sdf,
-                     std::string& modelica_model,
-                     const SDFModelicaOptions options)
+bool modelicaFromSDF(sdf::SDFPtr sdf, std::string& modelica_model, const SDFModelicaOptions options)
 {
-  // We build a ign-math graph of the Modelica components
-  // to simplify generating graphical annotations via graphviz
-  DiagramGraph modelGraph;
+    // We build a ign-math graph of the Modelica components
+    // to simplify generating graphical annotations via graphviz
+    DiagramGraph modelGraph;
 
-  const sdf::ElementPtr rootElement = sdf->Root();
-  if (!rootElement->HasElement("model"))
-  {
-    std::cerr << "sdf_modelica: Passed SDF does not contain a model." << std::endl;
-    return false;
-  }
-  const sdf::ElementPtr modelElement = rootElement->GetElement("model");
+    const sdf::ElementPtr rootElement = sdf->Root();
+    if (!rootElement->HasElement("model")) {
+        std::cerr << "sdf_modelica: Passed SDF does not contain a model." << std::endl;
+        return false;
+    }
+    const sdf::ElementPtr modelElement = rootElement->GetElement("model");
 
-  // Populate json-like data structure that will be consumed by the template
-  // nlohmann::json is used for the internal representation of the data due to
-  // its maturity and documentation, but it is in the end converted to
-  // kainjow::mustache::data for using the kainjow::mustache mustache template library
-  nlohmann::json data;
+    // Populate json-like data structure that will be consumed by the template
+    // nlohmann::json is used for the internal representation of the data due to
+    // its maturity and documentation, but it is in the end converted to
+    // kainjow::mustache::data for using the kainjow::mustache mustache template library
+    nlohmann::json data;
 
-  // Original filename
-  data["fileName"] = options.originalFilename;
+    // Original filename
+    data["fileName"] = options.originalFilename;
 
-  // modelName
-  const std::string tmpModelName=modelElement->Get<std::string>("name");
-  data["modelName"] = tmpModelName;
-  
-  // Modelica Language specification Version 3.3 Appendix B
-  if (!std::regex_match (tmpModelName, std::regex("\\w+") ))
-  {
-    std::cerr << "sdf_modelica: Passed SDF modelName contains not allowed char:"<<tmpModelName << std::endl;
-    return false;
-  }
-      
-  std::map<std::string, ignition::math::Pose3d> linkPoses;
+    // modelName
+    const std::string tmpModelName = modelElement->Get<std::string>("name");
+    data["modelName"] = tmpModelName;
 
-  // parse model links
-  nlohmann::json links = nlohmann::json::array();
-  sdf::ElementPtr linkElement = modelElement->GetElement("link");
-
-
-  // Handle world
-  std::map<std::string, ignition::math::graph::VertexId> modelicaComponent2ignGraphId;
-  modelicaComponent2ignGraphId["world"] = modelGraph.AddVertex("world", ModelicaGraphComponentInfo("world")).Id();
-
-  while (linkElement)
-  {
-    nlohmann::json link;
-
-    const std::string linkName = linkElement->Get<std::string>("name");
-    link["name"] = linkName;
     // Modelica Language specification Version 3.3 Appendix B
-    if (!std::regex_match (linkName, std::regex("\\w+") ))
-    {
-      std::cerr << "sdf_modelica: Passed SDF link name contains not allowed char:"<<linkName << std::endl;
-      return false;
+    if (!std::regex_match(tmpModelName, std::regex("\\w+"))) {
+        std::cerr << "sdf_modelica: Passed SDF modelName contains not allowed char:" << tmpModelName
+                  << std::endl;
+        return false;
     }
 
-    // Set default values
-    ignition::math::Pose3d inertiaPose = ignition::math::Pose3d::Zero;
-    ignition::math::MassMatrix3d massMatrix = ignition::math::MassMatrix3d(1.0,
-                                                                           ignition::math::Vector3d::One,
-                                                                           ignition::math::Vector3d::Zero);
+    std::map<std::string, ignition::math::Pose3d> linkPoses;
 
-    if (linkElement->HasElement("inertial"))
-    {
-      sdf::ElementPtr inertialElem = linkElement->GetElement("inertial");
-      if (inertialElem->HasElement("pose"))
-      {
-        inertiaPose =
-          inertialElem->GetElement("pose")->Get<ignition::math::Pose3d>("", ignition::math::Pose3d::Zero).first;
-      }
+    // parse model links
+    nlohmann::json links = nlohmann::json::array();
+    sdf::ElementPtr linkElement = modelElement->GetElement("link");
 
-      // Get the mass.
-      massMatrix.Mass(inertialElem->Get<double>("mass", 1.0).first);
+    // Handle world
+    std::map<std::string, ignition::math::graph::VertexId> modelicaComponent2ignGraphId;
+    modelicaComponent2ignGraphId["world"]
+        = modelGraph.AddVertex("world", ModelicaGraphComponentInfo("world")).Id();
 
-      if (inertialElem->HasElement("inertia"))
-      {
-        sdf::ElementPtr inertiaElem = inertialElem->GetElement("inertia");
-        massMatrix.IXX(inertiaElem->Get<double>("ixx", 1.0).first);
-        massMatrix.IYY(inertiaElem->Get<double>("iyy", 1.0).first);
-        massMatrix.IZZ(inertiaElem->Get<double>("izz", 1.0).first);
-        massMatrix.IXY(inertiaElem->Get<double>("ixy", 0.0).first);
-        massMatrix.IXZ(inertiaElem->Get<double>("ixz", 0.0).first);
-        massMatrix.IYZ(inertiaElem->Get<double>("iyz", 0.0).first);
-      }
+    while (linkElement) {
+        nlohmann::json link;
+
+        const std::string linkName = linkElement->Get<std::string>("name");
+        link["name"] = linkName;
+        // Modelica Language specification Version 3.3 Appendix B
+        if (!std::regex_match(linkName, std::regex("\\w+"))) {
+            std::cerr << "sdf_modelica: Passed SDF link name contains not allowed char:" << linkName
+                      << std::endl;
+            return false;
+        }
+
+        // Set default values
+        ignition::math::Pose3d inertiaPose = ignition::math::Pose3d::Zero;
+        ignition::math::MassMatrix3d massMatrix = ignition::math::MassMatrix3d(
+            1.0, ignition::math::Vector3d::One, ignition::math::Vector3d::Zero);
+
+        if (linkElement->HasElement("inertial")) {
+            sdf::ElementPtr inertialElem = linkElement->GetElement("inertial");
+            if (inertialElem->HasElement("pose")) {
+                inertiaPose = inertialElem->GetElement("pose")
+                                  ->Get<ignition::math::Pose3d>("", ignition::math::Pose3d::Zero)
+                                  .first;
+            }
+
+            // Get the mass.
+            massMatrix.Mass(inertialElem->Get<double>("mass", 1.0).first);
+
+            if (inertialElem->HasElement("inertia")) {
+                sdf::ElementPtr inertiaElem = inertialElem->GetElement("inertia");
+                massMatrix.IXX(inertiaElem->Get<double>("ixx", 1.0).first);
+                massMatrix.IYY(inertiaElem->Get<double>("iyy", 1.0).first);
+                massMatrix.IZZ(inertiaElem->Get<double>("izz", 1.0).first);
+                massMatrix.IXY(inertiaElem->Get<double>("ixy", 0.0).first);
+                massMatrix.IXZ(inertiaElem->Get<double>("ixz", 0.0).first);
+                massMatrix.IYZ(inertiaElem->Get<double>("iyz", 0.0).first);
+            }
+        }
+
+        if (!isIdentity(inertiaPose.Rot())) {
+            ignition::math::Matrix3d link_H_inertial = ignition::math::Matrix3d(inertiaPose.Rot());
+            massMatrix.MOI(link_H_inertial * massMatrix.MOI() * link_H_inertial.Transposed());
+        }
+
+        link["mass"] = std::to_string(massMatrix.Mass());
+        link["centerOfMass"] = toModelicaVector(inertiaPose.Pos());
+        link["I_11"] = std::to_string(massMatrix.IXX());
+        link["I_22"] = std::to_string(massMatrix.IYY());
+        link["I_33"] = std::to_string(massMatrix.IZZ());
+        link["I_21"] = std::to_string(massMatrix.IXY());
+        link["I_31"] = std::to_string(massMatrix.IXZ());
+        link["I_23"] = std::to_string(massMatrix.IYZ());
+
+        // Store the initial pose of each link, it is necessary for computing the joint transforms
+        linkPoses[linkName] = linkElement->GetElement("pose")
+                                  ->Get<ignition::math::Pose3d>("", ignition::math::Pose3d::Zero)
+                                  .first;
+
+        links.push_back(link);
+        modelicaComponent2ignGraphId[linkName] = modelGraph.AddVertex(linkName, linkName).Id();
+
+        linkElement = linkElement->GetNextElement("link");
     }
+    data["links"] = links;
 
-    if (!isIdentity(inertiaPose.Rot()))
-    {
-        ignition::math::Matrix3d link_H_inertial = ignition::math::Matrix3d(inertiaPose.Rot());
-        massMatrix.MOI(link_H_inertial*massMatrix.MOI()*link_H_inertial.Transposed());
-    }
+    // parse model joints
+    nlohmann::json joints = nlohmann::json::array();
+    sdf::ElementPtr jointElement = modelElement->GetElement("joint");
+    while (jointElement) {
+        nlohmann::json joint;
 
-    link["mass"] = std::to_string(massMatrix.Mass());
-    link["centerOfMass"] = toModelicaVector(inertiaPose.Pos());
-    link["I_11"] = std::to_string(massMatrix.IXX());
-    link["I_22"] = std::to_string(massMatrix.IYY());
-    link["I_33"] = std::to_string(massMatrix.IZZ());
-    link["I_21"] = std::to_string(massMatrix.IXY());
-    link["I_31"] = std::to_string(massMatrix.IXZ());
-    link["I_23"] = std::to_string(massMatrix.IYZ());
+        const std::string jointName = jointElement->Get<std::string>("name");
+        joint["name"] = jointName;
+        // Modelica Language specification Version 3.3 Appendix B
+        if (!std::regex_match(jointName, std::regex("\\w+"))) {
+            std::cerr << "sdf_modelica: Passed SDF joint name contains not allowed char:"
+                      << jointName << std::endl;
+            return false;
+        }
 
-    // Store the initial pose of each link, it is necessary for computing the joint transforms
-    linkPoses[linkName] = linkElement->GetElement("pose")->Get<ignition::math::Pose3d>("", ignition::math::Pose3d::Zero).first;
+        std::string jointType = jointElement->Get<std::string>("type");
+        joint["type"] = jointType;
 
-    links.push_back(link);
-    modelicaComponent2ignGraphId[linkName] = modelGraph.AddVertex(linkName, linkName).Id();
+        if (!((jointType == "revolute") || (jointType == "prismatic") || (jointType == "fixed"))) {
+            std::cerr << "sdf_modelica: type " << jointType << " of joint " << jointName
+                      << " not supported, parsing failed." << std::endl;
+            return false;
+        }
 
-    linkElement = linkElement->GetNextElement("link");
-  }
-  data["links"] = links;
+        joint["isType_" + jointType] = true;
 
-  // parse model joints
-  nlohmann::json joints = nlohmann::json::array();
-  sdf::ElementPtr jointElement = modelElement->GetElement("joint");
-  while (jointElement)
-  {
-    nlohmann::json joint;
+        std::string parentLink, childLink;
+        joint["parentLink"] = parentLink = jointElement->GetElement("parent")->Get<std::string>();
+        joint["childLink"] = childLink = jointElement->GetElement("child")->Get<std::string>();
+        if (parentLink == "world") {
+            joint["parentLinkIsWorld"] = true;
+        }
 
-    const std::string jointName = jointElement->Get<std::string>("name");
-    joint["name"] = jointName;
-   // Modelica Language specification Version 3.3 Appendix B
-    if (!std::regex_match (jointName, std::regex("\\w+") ))
-    {
-      std::cerr << "sdf_modelica: Passed SDF joint name contains not allowed char:"<<jointName << std::endl;
-      return false;
-    }
+        // The joint transformation is encoded in the SDF format in the
+        // initial pose of each link
+        ignition::math::Pose3d model_T_parentLink
+            = linkPoses[jointElement->GetElement("parent")->Get<std::string>()];
+        ignition::math::Pose3d model_T_childLink
+            = linkPoses[jointElement->GetElement("child")->Get<std::string>()];
+        ignition::math::Pose3d parentLink_T_childLink
+            = SE3Multiplication(model_T_parentLink.Inverse(), model_T_childLink);
 
-    std::string jointType = jointElement->Get<std::string>("type");
-    joint["type"] = jointType;
+        // Extract the fixed parent <---> child transform
+        joint["fixedTransformTrans"] = toModelicaVector(parentLink_T_childLink.Pos());
+        ignition::math::Vector3d rotAxis;
+        double rotAngle;
+        parentLink_T_childLink.Rot().ToAxis(rotAxis, rotAngle);
+        joint["fixedTransformAxis"] = toModelicaVector(rotAxis);
+        // TODO(traversaro) : handle precision and locale issues
+        joint["fixedTransformAngle"] = std::to_string(rotAngle);
 
-    if ( !( (jointType == "revolute") ||
-            (jointType == "prismatic") ||
-            (jointType == "fixed") ) )
-    {
-      std::cerr << "sdf_modelica: type " << jointType
-                << " of joint " << jointName << " not supported, parsing failed."
-                << std::endl;
-      return false;
-    }
+        if ((jointType == "revolute") || (jointType == "prismatic")) {
+            // In sdf, the axis of the joint is expressed in the child frame, unless
+            // use_parent_model_frame is set to true
 
-    joint["isType_"+jointType] = true;
+            // TODO(traversaro) : handle use_parent_model_frame
+            ignition::math::Vector3d axisInSDF = jointElement->GetElement("axis")
+                                                     ->GetElement("xyz")
+                                                     ->Get<ignition::math::Vector3d>();
+            bool use_parent_model_frame = jointElement->GetElement("axis")
+                                              ->GetElement("use_parent_model_frame")
+                                              ->Get<bool>();
+            ignition::math::Vector3d axisInChildFrame;
 
-    std::string parentLink, childLink;
-    joint["parentLink"] = parentLink = jointElement->GetElement("parent")->Get<std::string>();
-    joint["childLink"] =  childLink  = jointElement->GetElement("child")->Get<std::string>();
-    if (parentLink == "world")
-    {
-      joint["parentLinkIsWorld"] = true;
-    }
+            if (use_parent_model_frame) {
+                axisInChildFrame = model_T_childLink.Rot().Inverse() * (axisInSDF);
+            } else {
+                axisInChildFrame = axisInSDF;
+            }
 
-    // The joint transformation is encoded in the SDF format in the
-    // initial pose of each link
-    ignition::math::Pose3d model_T_parentLink = linkPoses[jointElement->GetElement("parent")->Get<std::string>()];
-    ignition::math::Pose3d model_T_childLink = linkPoses[jointElement->GetElement("child")->Get<std::string>()];
-    ignition::math::Pose3d parentLink_T_childLink = SE3Multiplication(model_T_parentLink.Inverse(), model_T_childLink);
+            joint["modelicaAxis"] = toModelicaVector(axisInChildFrame);
+        }
 
-    // Extract the fixed parent <---> child transform
-    joint["fixedTransformTrans"] = toModelicaVector(parentLink_T_childLink.Pos());
-    ignition::math::Vector3d rotAxis;
-    double rotAngle;
-    parentLink_T_childLink.Rot().ToAxis(rotAxis, rotAngle);
-    joint["fixedTransformAxis"] = toModelicaVector(rotAxis);
-    // TODO(traversaro) : handle precision and locale issues
-    joint["fixedTransformAngle"] = std::to_string(rotAngle);
+        // For each joint we have one modelica component: the fixed transformation,
+        // and for joints with non-zero DOF we also have the joint component
+        modelicaComponent2ignGraphId[jointName + "_fixedRotation"]
+            = modelGraph.AddVertex(jointName + "_fixedRotation", jointName + "_fixedRotation").Id();
 
-    if ( (jointType == "revolute") || (jointType == "prismatic") )
-    {
-      // In sdf, the axis of the joint is expressed in the child frame, unless use_parent_model_frame is set to true
-
-      // TODO(traversaro) : handle use_parent_model_frame
-      ignition::math::Vector3d axisInSDF= jointElement->GetElement("axis")->GetElement("xyz")->Get<ignition::math::Vector3d>();
-      bool use_parent_model_frame = jointElement->GetElement("axis")->GetElement("use_parent_model_frame")->Get<bool>();
-      ignition::math::Vector3d axisInChildFrame;
-
-      if (use_parent_model_frame)
-      {
-        axisInChildFrame = model_T_childLink.Rot().Inverse()*(axisInSDF);
-      }
-      else
-      {
-        axisInChildFrame = axisInSDF;
-      }
-
-      joint["modelicaAxis"] = toModelicaVector(axisInChildFrame);
-    }
-
-    // For each joint we have one modelica component: the fixed transformation,
-    // and for joints with non-zero DOF we also have the joint component
-    modelicaComponent2ignGraphId[jointName+"_fixedRotation"] = modelGraph.AddVertex(jointName+"_fixedRotation", jointName+"_fixedRotation").Id();
-
-    modelGraph.AddEdge(ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[parentLink], modelicaComponent2ignGraphId[jointName+"_fixedRotation"]),
+        modelGraph.AddEdge(ignition::math::graph::VertexId_P(
+                               modelicaComponent2ignGraphId[parentLink],
+                               modelicaComponent2ignGraphId[jointName + "_fixedRotation"]),
                            ModelicaGraphConnectionInfo(ConnectionSide::EAST, ConnectionSide::WEST));
 
-    if ( (jointType == "revolute") || (jointType == "prismatic") )
-    {
-        modelicaComponent2ignGraphId[jointName] = modelGraph.AddVertex(jointName, jointName).Id();
+        if ((jointType == "revolute") || (jointType == "prismatic")) {
+            modelicaComponent2ignGraphId[jointName]
+                = modelGraph.AddVertex(jointName, jointName).Id();
 
-        modelGraph.AddEdge(ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[jointName+"_fixedRotation"], modelicaComponent2ignGraphId[jointName]),
-                           ModelicaGraphConnectionInfo(EAST, WEST));
-        modelGraph.AddEdge(ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[jointName], modelicaComponent2ignGraphId[childLink]),
-                           ModelicaGraphConnectionInfo(EAST, EAST));
+            modelGraph.AddEdge(ignition::math::graph::VertexId_P(
+                                   modelicaComponent2ignGraphId[jointName + "_fixedRotation"],
+                                   modelicaComponent2ignGraphId[jointName]),
+                               ModelicaGraphConnectionInfo(EAST, WEST));
+            modelGraph.AddEdge(
+                ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[jointName],
+                                                  modelicaComponent2ignGraphId[childLink]),
+                ModelicaGraphConnectionInfo(EAST, EAST));
+        } else {
+            modelGraph.AddEdge(ignition::math::graph::VertexId_P(
+                                   modelicaComponent2ignGraphId[jointName + "_fixedRotation"],
+                                   modelicaComponent2ignGraphId[childLink]),
+                               ModelicaGraphConnectionInfo(EAST, EAST));
+        }
+
+        joints.push_back(joint);
+        jointElement = jointElement->GetNextElement("joint");
     }
-    else
-    {
-        modelGraph.AddEdge(ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[jointName+"_fixedRotation"], modelicaComponent2ignGraphId[childLink]),
-                          ModelicaGraphConnectionInfo(EAST, EAST));
+    data["joints"] = joints;
+
+    // Add graphical annotations
+    bool ok = add_icon_layout(modelGraph, data, modelicaComponent2ignGraphId);
+    if (!ok) {
+        std::cerr << "sdf_modelica: error in function add_icon_layout, exiting." << std::endl;
+        return false;
     }
 
-    joints.push_back(joint);
-    jointElement = jointElement->GetNextElement("joint");
-  }
-  data["joints"] = joints;
+    // For now, do not try to add diagram annotation as the results are still not ready
+    ok = add_diagram_layout_dummy(modelGraph, data);
+    if (!ok) {
+        std::cerr << "sdf_modelica: error in function add_diagram_layout_handtuned, exiting."
+                  << std::endl;
+        return false;
+    }
 
-  // Add graphical annotations
-  bool ok = add_icon_layout(modelGraph, data, modelicaComponent2ignGraphId);
-  if (!ok)
-  {
-     std::cerr << "sdf_modelica: error in function add_icon_layout, exiting." << std::endl;
-     return false;
-  }
+    // Load mustache template for the Modelica model
+    std::string mustache_template = SDF_MODELICA_TEMPLATE_PATH + "/mustache-modelica.txt";
 
-  // For now, do not try to add diagram annotation as the results are still not ready
-  ok = add_diagram_layout_dummy(modelGraph, data);
-  if (!ok)
-  {
-    std::cerr << "sdf_modelica: error in function add_diagram_layout_handtuned, exiting." << std::endl;
-    return false;
-  }
+    std::ifstream t(mustache_template);
+    std::string mustache_template_str((std::istreambuf_iterator<char>(t)),
+                                      std::istreambuf_iterator<char>());
 
-  // Load mustache template for the Modelica model
-  std::string mustache_template = SDF_MODELICA_TEMPLATE_PATH + "/mustache-modelica.txt";
+    kainjow::mustache::mustache tmpl{mustache_template_str};
 
-  std::ifstream t(mustache_template);
-  std::string mustache_template_str((std::istreambuf_iterator<char>(t)),
-                                     std::istreambuf_iterator<char>());
+    kainjow::mustache::data mustache_data = nlohmann_json_to_kainjow_mustache(data);
+    modelica_model = tmpl.render(mustache_data);
+    if (!tmpl.is_valid()) {
+        std::cerr << "sdf_modelica: mustache template not valid, error message: "
+                  << tmpl.error_message() << std::endl;
+        return false;
+    }
 
-  kainjow::mustache::mustache tmpl{mustache_template_str};
-
-  kainjow::mustache::data mustache_data = nlohmann_json_to_kainjow_mustache(data);
-  modelica_model = tmpl.render(mustache_data);
-  if (!tmpl.is_valid())
-  {
-    std::cerr << "sdf_modelica: mustache template not valid, error message: " << tmpl.error_message() << std::endl;
-    return false;
-  }
-
-  return true;
+    return true;
 }
 
-}
+} // namespace sdf_modelica

--- a/src/sdf-modelica-lib/src/sdf_modelica_diagram_layout.cpp
+++ b/src/sdf-modelica-lib/src/sdf_modelica_diagram_layout.cpp
@@ -11,38 +11,44 @@
 
 #include <sdf_modelica/sdf_modelica_diagram_layout.h>
 
-namespace sdf_modelica
-{
+namespace sdf_modelica {
 
-bool add_icon_layout(DiagramGraph& modelGraph,
-                     nlohmann::json& modelData,
-                     std::map<std::string, ignition::math::graph::VertexId>& modelicaComponent2ignGraphId)
+bool add_icon_layout(
+    DiagramGraph& modelGraph,
+    nlohmann::json& modelData,
+    std::map<std::string, ignition::math::graph::VertexId>& modelicaComponent2ignGraphId)
 {
     nlohmann::json& joints = modelData["joints"];
     int dofIndex = 0;
     std::stringstream ssIconFlangeLabels;
-    for (nlohmann::json::iterator it = joints.begin(); it != joints.end(); ++it)
-    {
+    for (nlohmann::json::iterator it = joints.begin(); it != joints.end(); ++it) {
         nlohmann::json& joint = *it;
 
         bool isTypeFixed = (joint.find("isType_fixed") != joint.end());
-        if (!isTypeFixed)
-        {
+        if (!isTypeFixed) {
             std::stringstream ss;
             std::string jointName = joint["name"];
             int modelicaFlangeX = -210;
-            int modelicaFlangeY = -170 + 40*dofIndex;
-            ss << "Placement(transformation(origin = {" << modelicaFlangeX << ", " << modelicaFlangeY << "}, extent={{-10, -10}, {10, 10}}))";
+            int modelicaFlangeY = -170 + 40 * dofIndex;
+            ss << "Placement(transformation(origin = {" << modelicaFlangeX << ", "
+               << modelicaFlangeY << "}, extent={{-10, -10}, {10, 10}}))";
             joint["flangeGraphicsAnnotation"] = ss.str();
             ssIconFlangeLabels << ",";
-            ssIconFlangeLabels << "Text(extent={ {-200, " << -150+40*dofIndex << "},{-140, " << -190+40*dofIndex << " } }, textString=\"" << jointName << "\", lineColor={0,0,255})";
-            std::string componentName = "axis_"+jointName;
-            modelicaComponent2ignGraphId[componentName] = modelGraph.AddVertex(componentName,
-                                                                               ModelicaGraphComponentInfo(componentName, true, modelicaFlangeX, modelicaFlangeY)).Id();
+            ssIconFlangeLabels << "Text(extent={ {-200, " << -150 + 40 * dofIndex << "},{-140, "
+                               << -190 + 40 * dofIndex << " } }, textString=\"" << jointName
+                               << "\", lineColor={0,0,255})";
+            std::string componentName = "axis_" + jointName;
+            modelicaComponent2ignGraphId[componentName]
+                = modelGraph
+                      .AddVertex(componentName,
+                                 ModelicaGraphComponentInfo(
+                                     componentName, true, modelicaFlangeX, modelicaFlangeY))
+                      .Id();
 
-            modelGraph.AddEdge(ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[componentName], modelicaComponent2ignGraphId[jointName]),
-                               ModelicaGraphConnectionInfo(ConnectionSide::EAST, ConnectionSide::NORTH));
-
+            modelGraph.AddEdge(
+                ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[componentName],
+                                                  modelicaComponent2ignGraphId[jointName]),
+                ModelicaGraphConnectionInfo(ConnectionSide::EAST, ConnectionSide::NORTH));
 
             dofIndex++;
         }
@@ -52,93 +58,95 @@ bool add_icon_layout(DiagramGraph& modelGraph,
     return true;
 }
 
-bool add_diagram_layout_handtuned(const DiagramGraph& modelGraph,
-                                  nlohmann::json& modelData)
+bool add_diagram_layout_handtuned(const DiagramGraph& modelGraph, nlohmann::json& modelData)
 {
-  std::map<std::string, int> link2index;
-  // Graphics annotation for the Modelica.Mechanics.MultiBody.World element included in the world
-  link2index["world"] = -1;
-  std::stringstream ssWorld;
-  ssWorld << "Placement(visible = true, transformation(origin = { " << -30 << ", " << -70 + 40*(-1) << "}, extent = {{-10, -10}, {10, 10}}, rotation = 180))";
-  modelData["worldGraphicsAnnotation"] = ssWorld.str();
+    std::map<std::string, int> link2index;
+    // Graphics annotation for the Modelica.Mechanics.MultiBody.World element included in the world
+    link2index["world"] = -1;
+    std::stringstream ssWorld;
+    ssWorld << "Placement(visible = true, transformation(origin = { " << -30 << ", "
+            << -70 + 40 * (-1) << "}, extent = {{-10, -10}, {10, 10}}, rotation = 180))";
+    modelData["worldGraphicsAnnotation"] = ssWorld.str();
 
-  // Set all the annotations to null
-  nlohmann::json& links = modelData["links"];
-  int linkIndex = 0;
-  for (nlohmann::json::iterator it = links.begin(); it != links.end(); ++it)
-  {
-      nlohmann::json& link = *it;
+    // Set all the annotations to null
+    nlohmann::json& links = modelData["links"];
+    int linkIndex = 0;
+    for (nlohmann::json::iterator it = links.begin(); it != links.end(); ++it) {
+        nlohmann::json& link = *it;
 
-      link2index[link["name"]] = linkIndex;
-      std::stringstream ss;
-      ss << "Placement(visible = true, transformation(origin = { " << -30 << ", " << -70 + 40*linkIndex << "}, extent = {{-10, -10}, {10, 10}}, rotation = 180))";
-      link["graphicsAnnotation"] = ss.str();
-      linkIndex++;
-  }
+        link2index[link["name"]] = linkIndex;
+        std::stringstream ss;
+        ss << "Placement(visible = true, transformation(origin = { " << -30 << ", "
+           << -70 + 40 * linkIndex << "}, extent = {{-10, -10}, {10, 10}}, rotation = 180))";
+        link["graphicsAnnotation"] = ss.str();
+        linkIndex++;
+    }
 
-  nlohmann::json& joints = modelData["joints"];
-  int jointIndex = 0;
-  for (nlohmann::json::iterator it = joints.begin(); it != joints.end(); ++it)
-  {
-      nlohmann::json& joint = *it;
+    nlohmann::json& joints = modelData["joints"];
+    int jointIndex = 0;
+    for (nlohmann::json::iterator it = joints.begin(); it != joints.end(); ++it) {
+        nlohmann::json& joint = *it;
 
-      std::string parentLink = joint["loparentLink"];
-      std::string childLink  = joint["childLink"];
+        std::string parentLink = joint["loparentLink"];
+        std::string childLink = joint["childLink"];
 
-      std::stringstream ss;
-      ss << "Placement(visible = true, transformation(origin = { " << 10 << ", " << -70 + 40*jointIndex << "}, extent = {{-10, -10}, {10, 10}}, rotation = 0))";
-      joint["fixedTranformGraphicsAnnotation"] = ss.str();
-      ss.str("");
-      ss << "Placement(visible = true, transformation(origin = { " << 50 << ", " << -70 + 40*jointIndex << "}, extent = {{-10, -10}, {10, 10}}, rotation = 0))";
-      joint["jointGraphicsAnnotation"] = ss.str();
-      ss.str("");
-      ss << "Line(points = {{-20, " << -70 + 40*link2index[parentLink] << "}, {0, " << -70 + 40*jointIndex << "}}, color = {95, 95, 95})";
-      joint["parent2fixedRotationGraphicsAnnotation"] = ss.str();
-      ss.str("");
-      ss << "Line(points = {{20, " << -70 + 40*jointIndex << "}, {40, " << -70 + 40*jointIndex << "}}, color = {95, 95, 95})";
-      joint["fixedRotation2jointGraphicsAnnotation"] = ss.str();
-      ss.str("");
-      ss << "Line(points = {{60, " << -70 + 40*jointIndex << "}, {-20, " << -70 + 40*link2index[childLink] << " }}, color = {95, 95, 95})";
-      joint["joint2childGraphicsAnnotation"] = ss.str();
-      ss.str("");
-      ss << "Line(points = {{20, " << -70 + 40*jointIndex << "}, {-20, " << -70 + 40*link2index[childLink] << " }}, color = {95, 95, 95})";
-      joint["fixedRotation2childGraphicsAnnotation"] = ss.str();
+        std::stringstream ss;
+        ss << "Placement(visible = true, transformation(origin = { " << 10 << ", "
+           << -70 + 40 * jointIndex << "}, extent = {{-10, -10}, {10, 10}}, rotation = 0))";
+        joint["fixedTranformGraphicsAnnotation"] = ss.str();
+        ss.str("");
+        ss << "Placement(visible = true, transformation(origin = { " << 50 << ", "
+           << -70 + 40 * jointIndex << "}, extent = {{-10, -10}, {10, 10}}, rotation = 0))";
+        joint["jointGraphicsAnnotation"] = ss.str();
+        ss.str("");
+        ss << "Line(points = {{-20, " << -70 + 40 * link2index[parentLink] << "}, {0, "
+           << -70 + 40 * jointIndex << "}}, color = {95, 95, 95})";
+        joint["parent2fixedRotationGraphicsAnnotation"] = ss.str();
+        ss.str("");
+        ss << "Line(points = {{20, " << -70 + 40 * jointIndex << "}, {40, " << -70 + 40 * jointIndex
+           << "}}, color = {95, 95, 95})";
+        joint["fixedRotation2jointGraphicsAnnotation"] = ss.str();
+        ss.str("");
+        ss << "Line(points = {{60, " << -70 + 40 * jointIndex << "}, {-20, "
+           << -70 + 40 * link2index[childLink] << " }}, color = {95, 95, 95})";
+        joint["joint2childGraphicsAnnotation"] = ss.str();
+        ss.str("");
+        ss << "Line(points = {{20, " << -70 + 40 * jointIndex << "}, {-20, "
+           << -70 + 40 * link2index[childLink] << " }}, color = {95, 95, 95})";
+        joint["fixedRotation2childGraphicsAnnotation"] = ss.str();
 
-      jointIndex++;
-  }
+        jointIndex++;
+    }
 
-  return true;
+    return true;
 }
 
-bool add_diagram_layout_dummy(const DiagramGraph& modelGraph,
-                              nlohmann::json& modelData)
+bool add_diagram_layout_dummy(const DiagramGraph& modelGraph, nlohmann::json& modelData)
 {
-  // Graphics annotation for the Modelica.Mechanics.MultiBody.World element included in the world
-  modelData["worldGraphicsAnnotation"] = "";
+    // Graphics annotation for the Modelica.Mechanics.MultiBody.World element included in the world
+    modelData["worldGraphicsAnnotation"] = "";
 
-  // Set all the annotations to null
-  nlohmann::json& links = modelData["links"];
+    // Set all the annotations to null
+    nlohmann::json& links = modelData["links"];
 
-  for (nlohmann::json::iterator it = links.begin(); it != links.end(); ++it)
-  {
-      nlohmann::json& link = *it;
-      link["graphicsAnnotation"] = "";
-  }
+    for (nlohmann::json::iterator it = links.begin(); it != links.end(); ++it) {
+        nlohmann::json& link = *it;
+        link["graphicsAnnotation"] = "";
+    }
 
-  nlohmann::json& joints = modelData["joints"];
+    nlohmann::json& joints = modelData["joints"];
 
-  for (nlohmann::json::iterator it = joints.begin(); it != joints.end(); ++it)
-  {
-      nlohmann::json& joint = *it;
-      joint["fixedTranformGraphicsAnnotation"] = "";
-      joint["jointGraphicsAnnotation"] = "";
-      joint["parent2fixedRotationGraphicsAnnotation"] = "";
-      joint["fixedRotation2jointGraphicsAnnotation"] = "";
-      joint["joint2childGraphicsAnnotation"] = "";
-      joint["fixedRotation2childGraphicsAnnotation"] = "";
-  }
+    for (nlohmann::json::iterator it = joints.begin(); it != joints.end(); ++it) {
+        nlohmann::json& joint = *it;
+        joint["fixedTranformGraphicsAnnotation"] = "";
+        joint["jointGraphicsAnnotation"] = "";
+        joint["parent2fixedRotationGraphicsAnnotation"] = "";
+        joint["fixedRotation2jointGraphicsAnnotation"] = "";
+        joint["joint2childGraphicsAnnotation"] = "";
+        joint["fixedRotation2childGraphicsAnnotation"] = "";
+    }
 
-  return true;
+    return true;
 }
 
-}
+} // namespace sdf_modelica

--- a/src/sdf-modelica-lib/src/sdf_modelica_diagram_layout_graphviz.cpp
+++ b/src/sdf-modelica-lib/src/sdf_modelica_diagram_layout_graphviz.cpp
@@ -16,14 +16,13 @@
 
 #include <iostream>
 
-namespace sdf_modelica
-{
+namespace sdf_modelica {
 
 // Ratio between graphviz inches and modelica units
 const double graphvizInches2modelica = 20.0;
 
 // Ratio between graphviz dots and modelica units
-const double graphvizDots2modelica = graphvizInches2modelica/72.0;
+const double graphvizDots2modelica = graphvizInches2modelica / 72.0;
 
 // Center of modelica diagram in dots
 const double modelicaCenter = 50.0;
@@ -34,8 +33,8 @@ const double modelicaCenter = 50.0;
 std::string toModelica(const pointf gv_pos)
 {
     std::stringstream ss;
-    ss << "{ " << std::ceil(graphvizDots2modelica*gv_pos.x-modelicaCenter)
-       << ", " << std::ceil(graphvizDots2modelica*gv_pos.y-modelicaCenter)  << "}";
+    ss << "{ " << std::ceil(graphvizDots2modelica * gv_pos.x - modelicaCenter) << ", "
+       << std::ceil(graphvizDots2modelica * gv_pos.y - modelicaCenter) << "}";
     return ss.str();
 }
 
@@ -50,7 +49,7 @@ struct ModelicaPoint
  */
 float toGraphvizInches(const int point)
 {
-    return (point + modelicaCenter)/graphvizInches2modelica;
+    return (point + modelicaCenter) / graphvizInches2modelica;
 }
 
 /**
@@ -72,31 +71,28 @@ std::string toModelicaLine(const splines* spl)
 {
     std::stringstream ss;
     ss << "{";
-    if((spl->list != 0))
-    {
+    if ((spl->list != 0)) {
         bezier bez = spl->list[0];
 
-        //If there is a starting point, add it to the line
+        // If there is a starting point, add it to the line
         /* TODO(traversaro): check this code
         if(bez.sflag == 1)
         {
             ss << toModelica(bez.sp) << ", ";
         }*/
 
-        //Loop over the curve points
-        for (int i=0; i<bez.size; i++)
-        {
+        // Loop over the curve points
+        for (int i = 0; i < bez.size; i++) {
             ss << toModelica(bez.list[i]);
 
             // If it is the last point of the spline and there is not ending point,
             // do not add the last comma
-            if (!(i == bez.size-1))
-            {
+            if (!(i == bez.size - 1)) {
                 ss << ", ";
             }
         }
 
-        //If there is an ending point, draw a line to it
+        // If there is an ending point, draw a line to it
         /* TODO(traversaro): check this code
         if(bez.eflag == 1)
         {
@@ -107,21 +103,19 @@ std::string toModelicaLine(const splines* spl)
     return ss.str();
 }
 
-ignition::math::graph::EdgeId edgeConnectingTwoVertices(const DiagramGraph& modelGraph,
-                                                        const ignition::math::graph::VertexId parentId,
-                                                        const ignition::math::graph::VertexId childId)
+ignition::math::graph::EdgeId
+edgeConnectingTwoVertices(const DiagramGraph& modelGraph,
+                          const ignition::math::graph::VertexId parentId,
+                          const ignition::math::graph::VertexId childId)
 {
     // Check all outboarding connections
     auto childEdges = modelGraph.IncidentsFrom(parentId);
-    for(auto& edge: childEdges)
-    {
-        if (edge.second.get().Tail() == childId)
-        {
+    for (auto& edge : childEdges) {
+        if (edge.second.get().Tail() == childId) {
             return edge.first;
         }
 
-        if (edge.second.get().Head() == childId)
-        {
+        if (edge.second.get().Head() == childId) {
             return edge.first;
         }
     }
@@ -129,42 +123,41 @@ ignition::math::graph::EdgeId edgeConnectingTwoVertices(const DiagramGraph& mode
     return ignition::math::graph::kNullId;
 }
 
-Agedge_t* gvEdgeConnectingTwoComponents(std::map<ignition::math::graph::EdgeId, Agedge_t *>& id2edge,
-                                        std::map<std::string, ignition::math::graph::VertexId>& modelicaComponentName2id,
-                                        const DiagramGraph& modelGraph,
-                                        const std::string& parentComponent,
-                                        const std::string& childComponent)
+Agedge_t* gvEdgeConnectingTwoComponents(
+    std::map<ignition::math::graph::EdgeId, Agedge_t*>& id2edge,
+    std::map<std::string, ignition::math::graph::VertexId>& modelicaComponentName2id,
+    const DiagramGraph& modelGraph,
+    const std::string& parentComponent,
+    const std::string& childComponent)
 {
-   ignition::math::graph::EdgeId edgeId = edgeConnectingTwoVertices(modelGraph,
-                                          modelicaComponentName2id[parentComponent],
-                                          modelicaComponentName2id[childComponent]);
-   assert(id2edge[edgeId]);
-   return id2edge[edgeId];
+    ignition::math::graph::EdgeId edgeId
+        = edgeConnectingTwoVertices(modelGraph,
+                                    modelicaComponentName2id[parentComponent],
+                                    modelicaComponentName2id[childComponent]);
+    assert(id2edge[edgeId]);
+    return id2edge[edgeId];
 }
 
-
-bool add_diagram_layout_graphviz(const DiagramGraph& modelGraph,
-                                 nlohmann::json& modelData)
+bool add_diagram_layout_graphviz(const DiagramGraph& modelGraph, nlohmann::json& modelData)
 {
     // Create cgraph graph from the DiagramGraph
-    Agraph_t *G;
+    Agraph_t* G;
     char* graphName = "g";
     G = agopen(graphName, Agdirected, NULL);
     agsafeset(G, "splines", "polyline", "");
 
-    std::map<ignition::math::graph::VertexId, Agnode_t *> id2node;
-    std::map<std::string, Agnode_t *> modelicaComponentName2node;
+    std::map<ignition::math::graph::VertexId, Agnode_t*> id2node;
+    std::map<std::string, Agnode_t*> modelicaComponentName2node;
     std::map<std::string, ignition::math::graph::VertexId> modelicaComponentName2id;
     auto vertices = modelGraph.Vertices();
-    for(auto& vertex: vertices)
-    {
+    for (auto& vertex : vertices) {
         Agnode_t* node = agidnode(G, vertex.first, 1);
         std::string nodeName = vertex.second.get().Name();
         std::vector<char> nodeNameCstr(nodeName.c_str(), nodeName.c_str() + nodeName.size() + 1);
         node = agnode(G, nodeNameCstr.data(), 1);
-        if (!node)
-        {
-            std::cerr << "Error in creading graphviz node for " << vertex.second.get().Name() << ", exiting." << std::endl;
+        if (!node) {
+            std::cerr << "Error in creading graphviz node for " << vertex.second.get().Name()
+                      << ", exiting." << std::endl;
             return false;
         }
 
@@ -173,12 +166,13 @@ bool add_diagram_layout_graphviz(const DiagramGraph& modelGraph,
         agsafeset(node, "height", "1", "");
         agsafeset(node, "width", "1", "");
 
-        if (vertex.second.get().Data().fixedLocation)
-        {
+        if (vertex.second.get().Data().fixedLocation) {
             std::stringstream ss;
             pointf gvPointInches;
-            gvPointInches.x = toGraphvizInches(vertex.second.get().Data().fixedLocationModelicaUnitsX);
-            gvPointInches.y = toGraphvizInches(vertex.second.get().Data().fixedLocationModelicaUnitsY);
+            gvPointInches.x
+                = toGraphvizInches(vertex.second.get().Data().fixedLocationModelicaUnitsX);
+            gvPointInches.y
+                = toGraphvizInches(vertex.second.get().Data().fixedLocationModelicaUnitsY);
             ss << gvPointInches.x << "," << gvPointInches.y;
             std::string ss_str = ss.str();
             std::vector<char> charvect(ss_str.begin(), ss_str.end());
@@ -187,48 +181,35 @@ bool add_diagram_layout_graphviz(const DiagramGraph& modelGraph,
             agsafeset(node, "pin", "true", "");
         }
 
-
         id2node[vertex.first] = node;
         modelicaComponentName2node[vertex.second.get().Name()] = node;
         modelicaComponentName2id[vertex.second.get().Name()] = vertex.first;
     }
 
-    std::map<ignition::math::graph::EdgeId, Agedge_t *> id2edge;
+    std::map<ignition::math::graph::EdgeId, Agedge_t*> id2edge;
     auto edges = modelGraph.Edges();
-    for(auto& edge: edges)
-    {
+    for (auto& edge : edges) {
         ignition::math::graph::VertexId parentEdge = edge.second.get().Vertices().first;
         ignition::math::graph::VertexId childEdge = edge.second.get().Vertices().second;
-        std::string edgeName = modelGraph.VertexFromId(parentEdge).Name() + "_" + modelGraph.VertexFromId(childEdge).Name();
+        std::string edgeName = modelGraph.VertexFromId(parentEdge).Name() + "_"
+                               + modelGraph.VertexFromId(childEdge).Name();
         std::vector<char> edgeNameCstr(edgeName.c_str(), edgeName.c_str() + edgeName.size() + 1);
-        Agedge_t* gvedge = agedge(G,
-                                  id2node[parentEdge],
-                                  id2node[childEdge],
-                                  edgeNameCstr.data(), 1);
-        if(edge.second.get().Data().firstSide == EAST)
-        {
+        Agedge_t* gvedge
+            = agedge(G, id2node[parentEdge], id2node[childEdge], edgeNameCstr.data(), 1);
+        if (edge.second.get().Data().firstSide == EAST) {
             agsafeset(gvedge, "tailport", "e", "");
-        }
-        else if(edge.second.get().Data().firstSide == WEST)
-        {
+        } else if (edge.second.get().Data().firstSide == WEST) {
             agsafeset(gvedge, "tailport", "w", "");
-        }
-        else
-        {
+        } else {
             assert(edge.second.get().Data().firstSide == NORTH);
             agsafeset(gvedge, "tailport", "n", "");
         }
 
-        if(edge.second.get().Data().secondSide == EAST)
-        {
+        if (edge.second.get().Data().secondSide == EAST) {
             agsafeset(gvedge, "headport", "e", "");
-        }
-        else if(edge.second.get().Data().secondSide == WEST)
-        {
+        } else if (edge.second.get().Data().secondSide == WEST) {
             agsafeset(gvedge, "headport", "w", "");
-        }
-        else
-        {
+        } else {
             assert(edge.second.get().Data().secondSide == NORTH);
             agsafeset(gvedge, "headport", "n", "");
         }
@@ -237,30 +218,28 @@ bool add_diagram_layout_graphviz(const DiagramGraph& modelGraph,
     }
 
     // Compute layout
-    GVC_t *gvc;
+    GVC_t* gvc;
     gvc = gvContext();
-    int status = gvLayout (gvc, G, "fdp");
-    if (status != 0)
-    {
-        std::cerr << "sdf_modelica: error in calling gvLayout "
-                  << agerrors() << " " << aglasterr() << std::endl;
+    int status = gvLayout(gvc, G, "fdp");
+    if (status != 0) {
+        std::cerr << "sdf_modelica: error in calling gvLayout " << agerrors() << " " << aglasterr()
+                  << std::endl;
         return false;
     }
 
     // Get node position for the world node
-    pointf gv_pos  = ND_coord(modelicaComponentName2node["world"]);
+    pointf gv_pos = ND_coord(modelicaComponentName2node["world"]);
 
     std::stringstream ssWorld;
-        ssWorld << "Placement(visible = true, transformation(origin = " << toModelica(gv_pos)
-           << ", extent = {{-10, -10}, {10, 10}}))";
+    ssWorld << "Placement(visible = true, transformation(origin = " << toModelica(gv_pos)
+            << ", extent = {{-10, -10}, {10, 10}}))";
     modelData["worldGraphicsAnnotation"] = ssWorld.str();
 
     // Get node positions for link nodes
     nlohmann::json& links = modelData["links"];
-    for (nlohmann::json::iterator it = links.begin(); it != links.end(); ++it)
-    {
+    for (nlohmann::json::iterator it = links.begin(); it != links.end(); ++it) {
         nlohmann::json& link = *it;
-        pointf gv_pos  = ND_coord(modelicaComponentName2node[link["name"]]);
+        pointf gv_pos = ND_coord(modelicaComponentName2node[link["name"]]);
 
         std::stringstream ss;
         ss << "Placement(visible = true, transformation(origin = " << toModelica(gv_pos)
@@ -270,23 +249,23 @@ bool add_diagram_layout_graphviz(const DiagramGraph& modelGraph,
 
     // Get node and edge positions for joint nodes and edges
     nlohmann::json& joints = modelData["joints"];
-    for (nlohmann::json::iterator it = joints.begin(); it != joints.end(); ++it)
-    {
+    for (nlohmann::json::iterator it = joints.begin(); it != joints.end(); ++it) {
         nlohmann::json& joint = *it;
 
         // Nodes
         std::string jointName = joint["name"];
-        pointf gv_pos_fixedRotation = ND_coord(modelicaComponentName2node[jointName+"_fixedRotation"]);
+        pointf gv_pos_fixedRotation
+            = ND_coord(modelicaComponentName2node[jointName + "_fixedRotation"]);
 
         std::stringstream ss;
-        ss << "Placement(visible = true, transformation(origin = " << toModelica(gv_pos_fixedRotation)
+        ss << "Placement(visible = true, transformation(origin = "
+           << toModelica(gv_pos_fixedRotation)
            << ", extent = {{-10, -10}, {10, 10}}, rotation = 0))";
         joint["fixedTranformGraphicsAnnotation"] = ss.str();
 
         bool isTypeFixed = (joint.find("isType_fixed") != joint.end());
-        if (!isTypeFixed)
-        {
-            pointf gv_pos_joint  = ND_coord(modelicaComponentName2node[joint["name"]]);
+        if (!isTypeFixed) {
+            pointf gv_pos_joint = ND_coord(modelicaComponentName2node[joint["name"]]);
             ss.str("");
             ss << "Placement(visible = true, transformation(origin = " << toModelica(gv_pos_joint)
                << ", extent = {{-10, -10}, {10, 10}}, rotation = 0))";
@@ -295,41 +274,47 @@ bool add_diagram_layout_graphviz(const DiagramGraph& modelGraph,
 
         // Edges
         std::string parentLink = joint["parentLink"];
-        std::string childLink  = joint["childLink"];
+        std::string childLink = joint["childLink"];
 
-        Agedge_t *edge = gvEdgeConnectingTwoComponents(id2edge, modelicaComponentName2id, modelGraph,
-                                                       parentLink, jointName+"_fixedRotation");
+        Agedge_t* edge = gvEdgeConnectingTwoComponents(id2edge,
+                                                       modelicaComponentName2id,
+                                                       modelGraph,
+                                                       parentLink,
+                                                       jointName + "_fixedRotation");
         const splines* spl = ED_spl(edge);
         ss.str("");
         ss << "Line(points = " << toModelicaLine(spl) << ", color = {95, 95, 95})";
         joint["parent2fixedRotationGraphicsAnnotation"] = ss.str();
-        if (isTypeFixed)
-        {
-            edge = gvEdgeConnectingTwoComponents(id2edge, modelicaComponentName2id, modelGraph,
-                                                  jointName+"_fixedRotation", childLink);
+        if (isTypeFixed) {
+            edge = gvEdgeConnectingTwoComponents(id2edge,
+                                                 modelicaComponentName2id,
+                                                 modelGraph,
+                                                 jointName + "_fixedRotation",
+                                                 childLink);
             spl = ED_spl(edge);
             ss.str("");
             ss << "Line(points = " << toModelicaLine(spl) << ", color = {95, 95, 95})";
             joint["fixedRotation2childGraphicsAnnotation"] = ss.str();
-        }
-        else
-        {
-            edge = gvEdgeConnectingTwoComponents(id2edge, modelicaComponentName2id, modelGraph,
-                                                  jointName+"_fixedRotation", jointName);
+        } else {
+            edge = gvEdgeConnectingTwoComponents(id2edge,
+                                                 modelicaComponentName2id,
+                                                 modelGraph,
+                                                 jointName + "_fixedRotation",
+                                                 jointName);
             spl = ED_spl(edge);
             ss.str("");
             ss << "Line(points = " << toModelicaLine(spl) << ", color = {95, 95, 95})";
             joint["fixedRotation2jointGraphicsAnnotation"] = ss.str();
-            edge = gvEdgeConnectingTwoComponents(id2edge, modelicaComponentName2id, modelGraph,
-                                                  jointName, childLink);
+            edge = gvEdgeConnectingTwoComponents(
+                id2edge, modelicaComponentName2id, modelGraph, jointName, childLink);
             spl = ED_spl(edge);
             ss.str("");
             ss << "Line(points = " << toModelicaLine(spl) << ", color = {95, 95, 95})";
             joint["joint2childGraphicsAnnotation"] = ss.str();
 
             // Add connection between flange and joint
-            edge = gvEdgeConnectingTwoComponents(id2edge, modelicaComponentName2id, modelGraph,
-                                                 "axis_"+jointName, jointName);
+            edge = gvEdgeConnectingTwoComponents(
+                id2edge, modelicaComponentName2id, modelGraph, "axis_" + jointName, jointName);
             spl = ED_spl(edge);
             ss.str("");
             ss << "Line(points = " << toModelicaLine(spl) << ", color = {95, 95, 95})";
@@ -342,10 +327,10 @@ bool add_diagram_layout_graphviz(const DiagramGraph& modelGraph,
 
     // Free resources
     gvFreeLayout(gvc, G);
-    agclose (G);
+    agclose(G);
     gvFreeContext(gvc);
 
     return true;
 }
 
-}
+} // namespace sdf_modelica

--- a/src/sdf-modelica-lib/test/diagram_layout_graphviz_test.cpp
+++ b/src/sdf-modelica-lib/test/diagram_layout_graphviz_test.cpp
@@ -13,8 +13,7 @@
 
 void dummyAssert(bool condition)
 {
-    if (!condition)
-    {
+    if (!condition) {
         exit(EXIT_FAILURE);
     }
 }
@@ -25,13 +24,15 @@ void testOneLinkLayout()
     nlohmann::json links = nlohmann::json::array();
     sdf_modelica::DiagramGraph modelGraph;
     std::map<std::string, ignition::math::graph::VertexId> modelicaComponent2ignGraphId;
-    modelicaComponent2ignGraphId["world"] = modelGraph.AddVertex("world", sdf_modelica::ModelicaGraphComponentInfo("world")).Id();
+    modelicaComponent2ignGraphId["world"]
+        = modelGraph.AddVertex("world", sdf_modelica::ModelicaGraphComponentInfo("world")).Id();
 
     // Add links
     nlohmann::json link;
     std::string linkName = link["name"] = "dummyLink";
     links.push_back(link);
-    modelicaComponent2ignGraphId[linkName] = modelGraph.AddVertex(linkName, sdf_modelica::ModelicaGraphComponentInfo(linkName)).Id();
+    modelicaComponent2ignGraphId[linkName]
+        = modelGraph.AddVertex(linkName, sdf_modelica::ModelicaGraphComponentInfo(linkName)).Id();
     modelData["links"] = links;
 
     // Add joints
@@ -39,10 +40,15 @@ void testOneLinkLayout()
     std::string parentLink = "world";
     std::string childLink = "dummyLink";
     modelicaComponent2ignGraphId[jointName] = modelGraph.AddVertex(jointName, jointName).Id();
-    modelGraph.AddEdge(ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[jointName+"_fixedRotation"], modelicaComponent2ignGraphId[jointName]),
-                       sdf_modelica::ModelicaGraphConnectionInfo(sdf_modelica::EAST, sdf_modelica::WEST));
-    modelGraph.AddEdge(ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[jointName], modelicaComponent2ignGraphId[childLink]),
-                       sdf_modelica::ModelicaGraphConnectionInfo(sdf_modelica::EAST, sdf_modelica::EAST));
+    modelGraph.AddEdge(
+        ignition::math::graph::VertexId_P(
+            modelicaComponent2ignGraphId[jointName + "_fixedRotation"],
+            modelicaComponent2ignGraphId[jointName]),
+        sdf_modelica::ModelicaGraphConnectionInfo(sdf_modelica::EAST, sdf_modelica::WEST));
+    modelGraph.AddEdge(
+        ignition::math::graph::VertexId_P(modelicaComponent2ignGraphId[jointName],
+                                          modelicaComponent2ignGraphId[childLink]),
+        sdf_modelica::ModelicaGraphConnectionInfo(sdf_modelica::EAST, sdf_modelica::EAST));
 
     // Generate layout for the graph
     bool ok = add_diagram_layout_graphviz(modelGraph, modelData);
@@ -50,7 +56,6 @@ void testOneLinkLayout()
 
     return;
 }
-
 
 int main(int argc, char** argv)
 {

--- a/src/sdf-modelica-lib/test/nlohmann_json_to_kainjow_mustache_test.cpp
+++ b/src/sdf-modelica-lib/test/nlohmann_json_to_kainjow_mustache_test.cpp
@@ -13,8 +13,7 @@
 
 void dummyAssert(bool condition)
 {
-    if (!condition)
-    {
+    if (!condition) {
         exit(EXIT_FAILURE);
     }
 }
@@ -31,27 +30,22 @@ void testArrayConversions()
     dummyAssert(km_array.is_list());
     kainjow::mustache::list km_list = km_array.list_value();
     dummyAssert(nj_array.size() == km_list.size());
-    for (int i=0; i < nj_array.size(); i++)
-    {
+    for (int i = 0; i < nj_array.size(); i++) {
         std::string nj_val;
-        if (nj_array[i].is_string())
-        {
+        if (nj_array[i].is_string()) {
             nj_val = nj_array[i];
         }
-        if (nj_array[i].is_number_integer())
-        {
+        if (nj_array[i].is_number_integer()) {
             int nj_val_int = nj_array[i];
             nj_val = std::to_string(nj_val_int);
         }
-        if (nj_array[i].is_number_float())
-        {
+        if (nj_array[i].is_number_float()) {
             double nj_val_dbl = nj_array[i];
             nj_val = std::to_string(nj_val_dbl);
         }
         dummyAssert(nj_val == km_list[i].string_value());
     }
 }
-
 
 int main(int argc, char** argv)
 {

--- a/src/sdf-modelica-lib/test/sdf_modelica_test.cpp
+++ b/src/sdf-modelica-lib/test/sdf_modelica_test.cpp
@@ -1,29 +1,28 @@
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 
 #include <sdf_modelica/sdf_modelica.h>
 
 void dummyAssert(bool condition)
 {
-  if (!condition)
-  {
-    exit(EXIT_FAILURE);
-  }
+    if (!condition) {
+        exit(EXIT_FAILURE);
+    }
 }
 
 void check_file(std::string file)
 {
-  std::string modelica_model;
-  bool ok = sdf_modelica::modelicaFromSDFFile(file, modelica_model);
-  std::cerr << "~~~~~~> Start generated modelica model <~~~~~" << std::endl;
-  std::cerr << modelica_model << std::endl;
-  std::cerr << "~~~~~~> End generated modelica model <~~~~~" << std::endl;
-  dummyAssert(ok);
+    std::string modelica_model;
+    bool ok = sdf_modelica::modelicaFromSDFFile(file, modelica_model);
+    std::cerr << "~~~~~~> Start generated modelica model <~~~~~" << std::endl;
+    std::cerr << modelica_model << std::endl;
+    std::cerr << "~~~~~~> End generated modelica model <~~~~~" << std::endl;
+    dummyAssert(ok);
 }
 
 int main(int argc, char** argv)
 {
-  check_file(argv[1]);
-  return EXIT_SUCCESS;
+    check_file(argv[1]);
+    return EXIT_SUCCESS;
 }

--- a/src/sdf2modelica/sdf2modelica.cpp
+++ b/src/sdf2modelica/sdf2modelica.cpp
@@ -11,31 +11,29 @@
 
 #include <sdf_modelica/sdf_modelica.h>
 
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-  // TODO(traversaro) : implement actual flag parsing
-  if (argc != 3)
-  {
-    std::cerr << "Usage: sdf2modelica inputModel.(sdf|urdf) outModel.mo" << std::endl;
+    // TODO(traversaro) : implement actual flag parsing
+    if (argc != 3) {
+        std::cerr << "Usage: sdf2modelica inputModel.(sdf|urdf) outModel.mo" << std::endl;
+        return EXIT_SUCCESS;
+    }
+
+    std::string modelicaModelString;
+    bool ok = sdf_modelica::modelicaFromSDFFile(argv[1], modelicaModelString);
+
+    if (!ok) {
+        std::cerr << "sdf2modelica: failure in parsing SDF model from " << argv[1] << std::endl;
+    }
+
+    std::string outputFileName = argv[2];
+    std::ofstream ofs(outputFileName.c_str(), std::ofstream::out);
+
+    ofs << modelicaModelString;
+
     return EXIT_SUCCESS;
-  }
-
-  std::string modelicaModelString;
-  bool ok = sdf_modelica::modelicaFromSDFFile(argv[1], modelicaModelString);
-
-  if (!ok)
-  {
-    std::cerr << "sdf2modelica: failure in parsing SDF model from " << argv[1] << std::endl;
-  }
-
-  std::string outputFileName = argv[2];
-  std::ofstream ofs (outputFileName.c_str(), std::ofstream::out);
-
-  ofs << modelicaModelString;
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Add a `.clang-format` file (from https://raw.githubusercontent.com/robotology-playground/clang-format/1811db969fc5adff4b5cd5a5d9c087aadd9265e0/clang-format) and a `clang-target` CMake target to automatically format with `clang-format` the source code of the repo. 
In https://github.com/robotology/sdf-modelica/commit/2b5a2b3b1af56fd0fac4182601addfaacd8edfae the clang-format file and target are added.  
https://github.com/robotology/sdf-modelica/commit/772caf9931f35911075e67ae72124a51e2234779 is just a big commit of the changes induced by running the new clang-format the first time. 